### PR TITLE
fix(github_nulls): Better handling of Nulls in GitHub API

### DIFF
--- a/repo_manager/github/branch_protections.py
+++ b/repo_manager/github/branch_protections.py
@@ -292,14 +292,18 @@ def check_repo_branch_protections(
                 diff_option(
                     "dismiss_stale_reviews",
                     config_bp.protection.pr_options.dismiss_stale_reviews,
-                    this_protection.required_pull_request_reviews.dismiss_stale_reviews,
+                    ## Had issues when the YAML defines this but the Repo has none (e.g. it's null in the cloud)
+                    None if (this_protection.required_pull_request_reviews is None) else \
+                        this_protection.required_pull_request_reviews.dismiss_stale_reviews,
                 )
             )
             diffs.append(
                 diff_option(
                     "require_code_owner_reviews",
                     config_bp.protection.pr_options.require_code_owner_reviews,
-                    this_protection.required_pull_request_reviews.require_code_owner_reviews,
+                    ## Had issues when the YAML defines this but the Repo has none (e.g. it's null in the cloud)
+                    None if (this_protection.required_pull_request_reviews is None) else \
+                        this_protection.required_pull_request_reviews.require_code_owner_reviews,
                 )
             )
             # for now, not checking dismissal options. Will note that in the docs

--- a/repo_manager/github/branch_protections.py
+++ b/repo_manager/github/branch_protections.py
@@ -285,7 +285,9 @@ def check_repo_branch_protections(
                 diff_option(
                     "required_approving_review_count",
                     config_bp.protection.pr_options.required_approving_review_count,
-                    this_protection.required_pull_request_reviews.required_approving_review_count,
+                    ## Had issues when the YAML defines this but the Repo has none (e.g. it's null in the cloud)
+                    None if (this_protection.required_pull_request_reviews is None) else \
+                        this_protection.required_pull_request_reviews.required_approving_review_count,
                 )
             )
             diffs.append(


### PR DESCRIPTION
This now converts nulls returned from GitHub API into appropriate value, such as an empty array etc., to make fields comparable even if missing.  Previously there were cases where the nulls from the GitHub API would cause an error when trying to perform the comparisons.

Fixes #31 