### PR TITLE
feat(new_bp_comparisons): New Branch Protection Comparisons previously omitted

### DIFF
--- a/repo_manager/utils/__init__.py
+++ b/repo_manager/utils/__init__.py
@@ -3,6 +3,9 @@ from typing import Any
 
 from actions_toolkit import core as actions_toolkit
 
+# Needed to handle extracting certain attributes/fields from nested objects and lists
+from itertools import repeat
+
 from repo_manager.github import get_github_client
 
 from ._inputs import INPUTS
@@ -104,3 +107,7 @@ def attr_to_kwarg(attr_name: str, obj: Any, kwargs: dict, transform_key: str = N
             kwargs[attr_name] = value
         else:
             kwargs[transform_key] = value
+
+# Allows use to extract a certain field on a list of objects into a list of strings etc.
+def objary_to_list(attr_name: str, obj: Any):
+    return list(map(getattr, obj, repeat(attr_name)))


### PR DESCRIPTION
Added the ability to include comparing whether or not the YAML and the Repo have the same settings for:
* Users and Teams that can bypass pull requirements
* Users and Teams that can dismiss pull requests