### PR TITLE
fix: pin to bullseye docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM python:3.11-slim AS builder
+FROM python:3.11-slim-bullseye AS builder
 WORKDIR /app
 
 # install build requirements
-RUN apt-get update && apt-get install -y binutils patchelf build-essential scons
+RUN apt-get update && apt-get install -y binutils patchelf build-essential scons upx
 
 # copy the app
 COPY ./ /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.11-slim AS builder
 WORKDIR /app
 
 # install build requirements
-RUN apt-get update && apt-get install -y binutils patchelf upx build-essential scons
+RUN apt-get update && apt-get install -y binutils patchelf build-essential scons
 
 # copy the app
 COPY ./ /app


### PR DESCRIPTION
python docker images have been updated to Debian 12 (bookworm) and it has caused problems for installing staticx and upx. 

Pin to bullseye for now. These images are just used in the builder, the main image is based on scratch. 