### PR TITLE
fix: Allow Action Test to Use PAT of target repo

### DIFF
--- a/.github/workflows/action-integration.yml
+++ b/.github/workflows/action-integration.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  pull_request_target:
 jobs:
   action-integration-testing:
     name: Action Integration Testing


### PR DESCRIPTION
This way you don't have to worry about your test results being different post pull-request.  This will solve issues for PRs from any forks that could potentially break your repo.

@andrewthetechie - you will see, this PR will fail the action test because of the permission and token differences despite no changes to the actual code in repo.

However, once you merge this PR it will pass in your repo...  Then if I re-open the PR you said caused issues, that passed the test before merge but failed once merged, it will now start failing for the same issue.

Defining this action to use [pull_request_target ](https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/)is the only way you will be able to ensure that your TEST properly identifies bugs both before and after merges.   Otherwise, does not matter whose fork you use, mine or other people, the test will provide false positives/negatives because of how GitHub works...  

I am assuming your repo is using a fine grained token now, because otherwise that last PR would have worked post merge..